### PR TITLE
Remove extra initial (blank) message for streaming requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "protobufjs": "^5.0.0",
     "ts-node": "^1.7.0",
     "tslint": "^4.0.0",
-    "typescript": "^2.1.0"
+    "typescript": "2.4.2"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "lodash": "^4.0.0",
-    "rxjs": "5.0.0-rc.5"
+    "rxjs": "5.4.2"
   },
   "devDependencies": {
     "@types/es6-promise": "0.0.32",

--- a/src/server/call.ts
+++ b/src/server/call.ts
@@ -48,10 +48,6 @@ export class Call {
       this.streamHandle = this.service.stub[camelMethod]((error: any, response: any) => {
         this.handleCallCallback(error, response);
       });
-      // If they sent some args (shouldn't happen usually) send it off anyway
-      if (args) {
-        this.streamHandle.write(args);
-      }
     } else if (rpcMeta.requestStream && rpcMeta.responseStream) {
       this.streamHandle = this.service.stub[camelMethod]();
       this.setCallHandlers(this.streamHandle);


### PR DESCRIPTION
Fixes #35 

As mentioned in that issue, AFAICT there doesn't seem to be any reason for this code path to exist, and right now it is erroneously triggered every time, because `args` is an empty buffer that evaluates as "truthy"